### PR TITLE
updated - mobile nav chevron to disregard pointer-events

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2164,7 +2164,8 @@ header.site-header .wrap {
         height: 15px;
         display: flex;
         align-items: center;
-        justify-content: center; }
+        justify-content: center;
+        pointer-events: none; }
         .mobile-navigation .primary-navigation > ul > li .chevron img {
           width: 100%; }
         @media (min-width: 1071px) {

--- a/assets/scss/partials/_mobile-navigation.scss
+++ b/assets/scss/partials/_mobile-navigation.scss
@@ -160,6 +160,7 @@
                     display: flex;
                     align-items: center;
                     justify-content: center;
+                    pointer-events: none;
 
                     img {
                         width: 100%;


### PR DESCRIPTION
This PR updates the mobile nav chevron with CSS `pointer-events: none;` to disregard mouse events. Fixes bug with mobile nav when clicking on these images.