### PR TITLE
Fix landing page content showing escaped html - dev

### DIFF
--- a/inc/loop.php
+++ b/inc/loop.php
@@ -380,9 +380,9 @@ function eqd_single_landing_page() {
 
 					<?php
 					if ( empty( $parameter_page ) ) {
-						echo esc_html( get_field( 'how_does_the_consult_work' ) );
+						echo wp_kses_post( get_field( 'how_does_the_consult_work' ) );
 					} else {
-						echo esc_html( get_field( 'how_does_the_consult_work', $parameter_page ) );
+						echo wp_kses_post( get_field( 'how_does_the_consult_work', $parameter_page ) );
 					}
 					?>
 				</div>

--- a/template-parts/blocks/calculator-signup-block/calculator-signup.php
+++ b/template-parts/blocks/calculator-signup-block/calculator-signup.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Calculator Signup Block.
- * 
+ *
  * @package      Equalize Digital Base Theme
  * @author       Equalize Digital
  * @since        1.0.0
@@ -54,11 +54,11 @@ $block_link = get_field( 'link' );
 		<div class="calculator-signup-container-content">
 			<h2 class="title"><?php echo esc_html( $block_title ); ?></h2>
 			<div class="text"><?php echo wp_kses_post( $copy ); ?></div>
-			<?php 
+			<?php
 			if ( ! empty( $block_link ) ) {
 				$url              = $link['url'];
 				$calculator_title = $link['title'];
-				if( $link['url'] ) {
+				if ( $link['url'] ) {
 					echo '<span class="content">';
 					echo '<a href="' . esc_url( $url ) . '" class="btn btn-dark-bg">';
 						echo esc_html( $calculator_title );
@@ -80,7 +80,7 @@ $block_link = get_field( 'link' );
 					}
 					$calculator_signup_title = $row['title'];
 					$context                 = $row['context'];
-					
+
 					echo '<div class="calculator-signup-container-content-list-item">';
 					if ( ! empty( $image ) ) {
 						echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $image_alt ) . '" />';
@@ -96,7 +96,7 @@ $block_link = get_field( 'link' );
 							echo wp_kses_post( $context );
 						echo '</span>';
 					}
-					
+
 					echo '</div>';
 					echo '</div>';
 				}

--- a/template-parts/blocks/resource-links/resource-links.php
+++ b/template-parts/blocks/resource-links/resource-links.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Resource Links Block Template.
- * 
+ *
  * @package      Equalize Digital Base Theme
  * @author       Equalize Digital
  * @since        1.0.0
@@ -49,7 +49,7 @@ $block_title = get_field( 'title' );
 		<div class="resource-links-container-links" role="tablist">
 		<div class="dropdown">
 				<button id="resource-links-dropdown" class="dropdown-select">
-				<?php 
+				<?php
 				$links = get_field( 'links' );
 				if ( $links ) {
 					foreach ( $links as $key => $row ) {
@@ -72,7 +72,7 @@ $block_title = get_field( 'title' );
 
 				</button>
 				<ul class="resource-links-dropdown-list" role="tablist">
-					<?php 
+					<?php
 					$links = get_field( 'links' );
 					if ( $links ) {
 						foreach ( $links as $key => $row ) {
@@ -105,15 +105,15 @@ $block_title = get_field( 'title' );
 								</li>
 							<?php endif; ?>
 
-								
+
 							<?php
 						}
 					}
 					?>
 				</ul>
 			</div>
-			
-			<?php 
+
+			<?php
 			$links = get_field( 'links' );
 			if ( $links ) {
 				foreach ( $links as $key => $row ) {
@@ -148,7 +148,7 @@ $block_title = get_field( 'title' );
 
 	<div class="resource-links-loop-container">
 
-		<?php 
+		<?php
 		$links = get_field( 'links' );
 		if ( $links ) {
 			foreach ( $links as $key => $row ) {
@@ -158,24 +158,24 @@ $block_title = get_field( 'title' );
 				if ( ! empty( $row['featured_image'] ) ) {
 					$featured_image = $row['featured_image']['url'];
 				}
-				
+
 				if ( ! empty( $row['category'] ) ) {
 					$category = $row['category'];
 				}
 				if ( ! empty( $row['selected_posts'] ) ) {
 					$selected_posts = $row['selected_posts'];
 				}
-				if( 'link' === $row['type_of_button'] ) {
+				if ( 'link' === $row['type_of_button'] ) {
 					continue;
 				}
 				?>
-					<div 
-						id="resource-link-<?php echo esc_attr( $key ); ?>" 
-						role="tabpanel" 
-						aria-labelledby="button-tab-<?php echo esc_attr( $key ); ?>" 
+					<div
+						id="resource-link-<?php echo esc_attr( $key ); ?>"
+						role="tabpanel"
+						aria-labelledby="button-tab-<?php echo esc_attr( $key ); ?>"
 						class="resource-links-loop-container-item <?php echo 0 === $key ? 'resource-links-loop-container-item--active' : ''; ?>"
 					>
-						
+
 						<div class="resource-links-loop-container-content">
 							<div class="resource-links-loop-container-content-featured">
 								<div class="resource-links-loop-container-content-featured-link">
@@ -197,15 +197,15 @@ $block_title = get_field( 'title' );
 							if ( $selected_posts ) {
 
 								$args = array(
-									'post_type' => 'post', 
+									'post_type' => 'post',
 									'post__in'  => $selected_posts,
 									'orderby'   => 'post__in',
 								);
 
 							} else {
 								$args = array(
-									'post_type'      => 'post', 
-									'posts_per_page' => 3, 
+									'post_type'      => 'post',
+									'posts_per_page' => 3,
 									'cat'            => $category,
 								);
 							}
@@ -215,7 +215,7 @@ $block_title = get_field( 'title' );
 							if ( $query->have_posts() ) {
 								while ( $query->have_posts() ) {
 									$query->the_post();
-											
+
 									// Get categories.
 									$categories = get_the_category();
 									if ( $categories ) {
@@ -223,7 +223,7 @@ $block_title = get_field( 'title' );
 									} else {
 										$category = '';
 									}
-											
+
 									$post_title       = get_the_title();
 									$post_link        = get_the_permalink();
 									$author_email     = get_the_author_meta( 'user_email' );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Description

This PR swaps a location relying on `esc_html` to use `wp_kses_post` instead so that escaped html does not appear in the output of parameterized landing pages.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below. Follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
- Related Basecamp To-do URL: 
- Related Support Ticket URL:

## Proof of Functionality
<!-- Provide screenshots, GIFs, videos, or links to a deployed version of the site demonstrating the changes. -->

## Accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [Accessibility Checker](https://wordpress.org/plugins/accessibility-checker/) or [WAVE](https://wave.webaim.org/) and addressed `Error` and `Warning` issues?

_For more info, check out the
[Accessibility Checker Documentation](https://equalizedigital.com/accessibility-checker/documentation/)._

## Quality assurance
- [ ] I have tested this code to the best of my abilities.
- [ ] I have run local linting and tests.
- [ ] I have checked that the base branch is correctly set.
- [ ] I have updated the documentation or README.md accordingly.

## [optional] Are there any post deployment tasks we need to perform?
<!-- List any tasks that need to be carried out once the PR is deployed. -->

## Additional Notes
<!-- Add any other information about the PR here. -->